### PR TITLE
Removed the deprecated harmony flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --harmony_rest_parameters
+#!/usr/bin/env node
 
 'use strict';
 
@@ -9,4 +9,6 @@ if (require.main === module) {
 	process.exit();
 }
 
-module.exports = exports = (...query) => google(query);
+module.exports = exports = function () {
+	google.apply(null, arguments);
+};

--- a/lib/google.js
+++ b/lib/google.js
@@ -59,12 +59,7 @@ function search(os, exec, query) {
 		];
 	}
 
-	exec([
-		cmd,
-		' ',
-		'https://www.google.com',
-		...fullQuery
-	].join(''));
+	exec([cmd, ' https://www.google.com'].concat(fullQuery).join(''));
 }
 
 module.exports = exports = query => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-search-cli",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "CLI tool to launch Google Search in the default browser",
   "engines": {
     "node": ">=5.0.0"
@@ -42,6 +42,9 @@
   },
   "xo": {
     "esnext": true,
+    "rules": {
+      "prefer-spread": 0
+    },
     "globals": [
       "it",
       "describe",


### PR DESCRIPTION
Hi,

I'm getting an error when I try to run this package from the Shell (Mac OSX and Node v10.8). It looks like the `--harmony_rest-parameters` flag is deprecated, so here's a PR to replace the rest param usage (as well as the array spread, just in case) so that early versions of Node can run it (and later versions won't fail on the deprecated Node flag).

I tend to transpile when it makes sense to do so, and maybe you want to go that route instead? If not, this might be the simplest fix for it.